### PR TITLE
Simplify configuration

### DIFF
--- a/python_scripts/shellies_discovery.py
+++ b/python_scripts/shellies_discovery.py
@@ -143,7 +143,6 @@ relays = 0
 rollers = 0
 meters = 0
 relay_components = [ATTR_SWITCH, ATTR_LIGHT, ATTR_FAN]
-config_light = ATTR_RGBW
 relays_sensors = []
 relays_sensors_units = []
 relays_sensors_tpls = []
@@ -882,10 +881,7 @@ for light_id in range(0, rgbw_lights):
     availability_topic = "~online"
     unique_id = f"{id}-light-{light_id}"
     config_topic = f"{disc_prefix}/light/{id}-{light_id}/config"
-    if data.get(id):
-        config_light = data.get(id)
-    elif data.get(id.lower()):
-        config_light = data.get(id.lower())
+    config_light = data.get(id, data.get(id.lower(), ATTR_RGBW))
     if config_light == ATTR_RGBW and model == ATTR_MODEL_SHELLYRGBW2:
         payload = (
             '{"schema":"template",'
@@ -1133,10 +1129,7 @@ for light_id in range(0, white_lights):
         unique_id = f"{id}-light-white-{light_id}"
         config_topic = f"{disc_prefix}/light/{id}-white-{light_id}/config"
     availability_topic = "~online"
-    if data.get(id):
-        config_light = data.get(id)
-    elif data.get(id.lower()):
-        config_light = data.get(id.lower())
+    config_light = data.get(id, data.get(id.lower(), ATTR_RGBW))
     if config_light == ATTR_WHITE and model == ATTR_MODEL_SHELLYRGBW2:
         payload = (
             '{"schema":"template",'

--- a/python_scripts/shellies_discovery.py
+++ b/python_scripts/shellies_discovery.py
@@ -745,10 +745,7 @@ for sensor_id in range(0, len(sensors)):
 for sensor_id in range(0, ext_sensors):
     device_name = f"{model} {id.split('-')[-1]}"
     unique_id = f"{id}-ext-{sensor_id}"
-    if data.get(unique_id):
-        ext_sensor_type = data.get(unique_id)
-    elif data.get(unique_id.lower()):
-        ext_sensor_type = data.get(unique_id.lower())
+    ext_sensor_type = data.get(unique_id, data.get(unique_id.lower()))
     if ext_sensor_type:
         config_topic = f"{disc_prefix}/sensor/{id}-ext-{sensor_id}/config"
         default_topic = f"shellies/{id}/"

--- a/python_scripts/shellies_discovery.py
+++ b/python_scripts/shellies_discovery.py
@@ -692,9 +692,8 @@ for sensor_id in range(0, len(sensors)):
         state_topic = f"~{sensors[sensor_id]}"
     else:
         state_topic = f"~sensor/{sensors[sensor_id]}"
-    if data.get(id) or data.get(id.lower()):
-        if (data.get(id) or data.get(id.lower())) == ATTR_AC_POWER:
-            expire_after = 7200
+    if data.get(id, data.get(id.lower())) == ATTR_AC_POWER:
+        expire_after = 7200
     if battery_powered:
         payload = (
             '{"name":"' + sensor_name + '",'

--- a/python_scripts/shellies_discovery.py
+++ b/python_scripts/shellies_discovery.py
@@ -143,7 +143,6 @@ relays = 0
 rollers = 0
 meters = 0
 relay_components = [ATTR_SWITCH, ATTR_LIGHT, ATTR_FAN]
-config_component = ATTR_SWITCH
 config_light = ATTR_RGBW
 relays_sensors = []
 relays_sensors_units = []
@@ -453,10 +452,7 @@ for roller_id in range(0, rollers):
     set_position_topic = f"{state_topic}/command/pos"
     availability_topic = "~online"
     unique_id = f"{id}-roller-{roller_id}"
-    if data.get(id):
-        config_component = data.get(id)
-    elif data.get(id.lower()):
-        config_component = data.get(id.lower())
+    config_component = data.get(id, data.get(id.lower()))
     component = ATTR_COVER
     config_topic = f"{disc_prefix}/{component}/{id}-roller-{roller_id}/config"
     if config_component == component:
@@ -504,10 +500,7 @@ for relay_id in range(0, relays):
     command_topic = f"{state_topic}/command"
     availability_topic = "~online"
     unique_id = f"{id}-relay-{relay_id}"
-    if data.get(unique_id):
-        config_component = data.get(unique_id)
-    elif data.get(unique_id.lower()):
-        config_component = data.get(unique_id.lower())
+    config_component = data.get(unique_id, data.get(unique_id.lower(), ATTR_SWITCH))
     for component in relay_components:
         config_topic = f"{disc_prefix}/{component}/{id}-relay-{relay_id}/config"
         if component == config_component and not roller_mode:

--- a/python_scripts/shellies_discovery.py
+++ b/python_scripts/shellies_discovery.py
@@ -107,13 +107,11 @@ off_delay = 3
 retain = True
 qos = 0
 roller_mode = False
-ignored = []
 
 id = data.get(CONF_ID)
 mac = data.get(CONF_MAC)
 fw_ver = data.get(CONF_FW_VER)
-if data.get(CONF_IGNORED_DEVICES):
-    ignored = [element.lower() for element in data.get(CONF_IGNORED_DEVICES)]
+ignored = [element.lower() for element in data.get(CONF_IGNORED_DEVICES, [])]
 
 if not id:
     raise ValueError(f"{id} is wrong id argument")


### PR DESCRIPTION
The configuration variables `config_component` and `config_light` are set to the default value once in the beginning of the script. This is a problem for Shelly 2.5 (and maybe others), if the config for `relay-0` is set to `light`, but the config for `relay-1` is unset and should stay `switch`. In that case, `config_component` is set to `light` when handling `relay-0`, and never set back to the default, so `relay-1`is set to `light` too.

I solved this by removing the global variables, and using the default parameter of `data.get()` instead.

In order to stay consistent, I did the same for other config variables.