### PR TITLE
Readme: fix small typo 'mode' should be queued

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ python_script:
   trigger:
     - platform: mqtt
       topic: shellies/announce
-  mode: queue
+  mode: queued
   max: 999
   action:
     service: python_script.shellies_discovery


### PR DESCRIPTION
Fix tiny typo in 'mode' parameter per https://www.home-assistant.io/integrations/script/#script-modes .