### PR TITLE
Fix Shelly 1L ip sensor topic

### DIFF
--- a/python_scripts/shellies_discovery.py
+++ b/python_scripts/shellies_discovery.py
@@ -720,14 +720,7 @@ if model_id == MODEL_SHELLY1L_ID or dev_id_prefix == MODEL_SHELLY1L_PREFIX:
         DEVICE_CLASS_TIMESTAMP,
         None,
     ]
-    sensors_topics = [
-        None,
-        TOPIC_INFO,
-        TOPIC_INFO,
-        TOPIC_INFO,
-        TOPIC_INFO,
-        TOPIC_ANNOUNCE,
-    ]
+    sensors_topics = [None, TOPIC_INFO, TOPIC_INFO, TOPIC_INFO, TOPIC_ANNOUNCE]
     sensors_tpls = [TPL_TEMPERATURE, TPL_RSSI, TPL_SSID, TPL_UPTIME, TPL_IP]
     sensors_units = [UNIT_CELSIUS, UNIT_DBM, None, None, None]
 


### PR DESCRIPTION
`sensors_topics` for Shelly 1L is the wrong size, so this sensor ended up using the info topic instead of the announce topic. This caused a `Template variable warning: 'dict object' has no attribute 'ip' when rendering '{{value_json.ip}}'`.