### PR TITLE
Fix KeyError on sensor_options[KEY_PAYLOAD][VALUE_ON] for Shelly Door/Window

### DIFF
--- a/python_scripts/shellies_discovery.py
+++ b/python_scripts/shellies_discovery.py
@@ -3407,8 +3407,12 @@ for sensor, sensor_options in binary_sensors.items():
     if sensor_options.get(KEY_VALUE_TEMPLATE):
         payload[KEY_VALUE_TEMPLATE] = sensor_options[KEY_VALUE_TEMPLATE]
     else:
-        payload[KEY_PAYLOAD_ON] = sensor_options[KEY_PAYLOAD][VALUE_ON]
-        payload[KEY_PAYLOAD_OFF] = sensor_options[KEY_PAYLOAD][VALUE_OFF]
+        if sensor_options.get(KEY_PAYLOAD):
+            payload[KEY_PAYLOAD_ON] = sensor_options[KEY_PAYLOAD][VALUE_ON]
+            payload[KEY_PAYLOAD_OFF] = sensor_options[KEY_PAYLOAD][VALUE_OFF]
+        else:
+            payload[KEY_PAYLOAD_ON] = sensor_options[KEY_PAYLOAD_ON]
+            payload[KEY_PAYLOAD_OFF] = sensor_options[KEY_PAYLOAD_OFF]
     if battery_powered:
         payload[KEY_EXPIRE_AFTER] = expire_after
     else:


### PR DESCRIPTION
Discussed on Issue #273 . 

Apparently there is no KEY_PAYLOAD in sensor options for binary sensor OPENING for Door/winow.

I am not sure this is the correct fix, but it fixed the exception and now the Shelly Door has the required binary sensor.
