### PR TITLE
Allow updating dimmer brightness when lamp is off

### DIFF
--- a/python_scripts/shellies_discovery.py
+++ b/python_scripts/shellies_discovery.py
@@ -3410,7 +3410,7 @@ for light_id, light_options in white_lights.items():
 
         mqtt_publish(config_topic, payload, retain)
 
-    # white light numbers
+    # light numbers
     for number, number_options in light_numbers.items():
         config_topic = (
             f"{disc_prefix}/number/{dev_id}-white-{number}-{light_id}/config".encode(

--- a/python_scripts/shellies_discovery.py
+++ b/python_scripts/shellies_discovery.py
@@ -2210,9 +2210,7 @@ if model_id == MODEL_SHELLYDIMMER_ID or dev_id_prefix == MODEL_SHELLYDIMMER_PREF
         SENSOR_ENERGY: OPTIONS_SENSOR_LIGHT_ENERGY,
         SENSOR_OVERPOWER_VALUE: OPTIONS_SENSOR_LIGHT_OVERPOWER_VALUE,
     }
-    light_numbers = {
-        NUMBER_LIGHT_BRIGHTNESS: OPTIONS_NUMBER_LIGHT_BRIGHTNESS
-    }
+    light_numbers = {NUMBER_LIGHT_BRIGHTNESS: OPTIONS_NUMBER_LIGHT_BRIGHTNESS}
     buttons = {BUTTON_RESTART: OPTIONS_BUTTON_RESTART}
     updates = {UPDATE_FIRMWARE: OPTIONS_UPDATE_FIRMWARE}
 
@@ -2248,9 +2246,7 @@ if model_id == MODEL_SHELLYDIMMER2_ID or dev_id_prefix == MODEL_SHELLYDIMMER2_PR
         SENSOR_ENERGY: OPTIONS_SENSOR_LIGHT_ENERGY,
         SENSOR_OVERPOWER_VALUE: OPTIONS_SENSOR_LIGHT_OVERPOWER_VALUE,
     }
-    light_numbers = {
-        NUMBER_LIGHT_BRIGHTNESS: OPTIONS_NUMBER_LIGHT_BRIGHTNESS
-    }
+    light_numbers = {NUMBER_LIGHT_BRIGHTNESS: OPTIONS_NUMBER_LIGHT_BRIGHTNESS}
     buttons = {BUTTON_RESTART: OPTIONS_BUTTON_RESTART}
     updates = {UPDATE_FIRMWARE: OPTIONS_UPDATE_FIRMWARE}
 
@@ -3416,13 +3412,17 @@ for light_id, light_options in white_lights.items():
 
     # white light numbers
     for number, number_options in light_numbers.items():
-        config_topic = f"{disc_prefix}/number/{dev_id}-white-{number}-{light_id}/config".encode(
-            "ascii", "ignore"
-        ).decode("utf-8")
+        config_topic = (
+            f"{disc_prefix}/number/{dev_id}-white-{number}-{light_id}/config".encode(
+                "ascii", "ignore"
+            ).decode("utf-8")
+        )
 
         payload = {
             KEY_NAME: f"{device_name} {format_entity_name(number)} {light_id}",
-            KEY_COMMAND_TOPIC: number_options[KEY_COMMAND_TOPIC].format(light_id=light_id),
+            KEY_COMMAND_TOPIC: number_options[KEY_COMMAND_TOPIC].format(
+                light_id=light_id
+            ),
             KEY_COMMAND_TEMPLATE: number_options[KEY_COMMAND_TEMPLATE].format(),
             KEY_MAX: number_options[KEY_MAX],
             KEY_MIN: number_options[KEY_MIN],

--- a/python_scripts/shellies_discovery.py
+++ b/python_scripts/shellies_discovery.py
@@ -351,6 +351,7 @@ MODEL_SHELLYUNI_PREFIX = "shellyuni"
 NUMBER_BOOST_TIME = "boost_time"
 NUMBER_MINIMAL_VALVE_POSITION = "minimal_valve_position"
 NUMBER_VALVE_POSITION = "valve_position"
+NUMBER_LIGHT_BRIGHTNESS = "brightness"
 
 OFF_DELAY = 1
 
@@ -514,6 +515,7 @@ TPL_COLOR_TEMP_WHITE_LIGHT = (
     "{{((1000000/(value_json.temp|int,2700)|max)|round(0,^floor^))}}"
 )
 TPL_COMMAND_ON_WHITE_LIGHT = "{{^turn^:^on^{{%if brightness is defined%}},^brightness^:{{{{brightness|float|multiply(0.3922)|round}}}}{{%endif%}}{{%if transition is defined%}},^transition^:{{{{min(transition|multiply(1000), {max_transition})}}}}{{%endif%}}}}"
+TPL_COMMAND_SET_BRIGHTNESS_WHITE_LIGHT = "{{^brightness^:{{{{value|float|round}}}}}}"
 TPL_COMMAND_ON_WHITE_LIGHT_DUO = "{{^turn^:^on^{{%if brightness is defined%}},^brightness^:{{{{brightness|float|multiply(0.3922)|round}}}}{{%endif%}}{{%if color_temp is defined%}},^temp^:{{{{(1000000/(color_temp|int))|round(0,^floor^)}}}}{{%endif%}}{{%if transition is defined%}},^transition^:{{{{min(transition|multiply(1000), {max_transition})}}}}{{%endif%}}}}"
 TPL_COMMAND_PROFILES = "{{value.split(^ ^)[-1]}}"
 TPL_CONCENTRATION = (
@@ -683,6 +685,18 @@ OPTIONS_NUMBER_MINIMAL_VALVE_POSITION = {
     KEY_ICON: "mdi:filter-minus-outline",
     KEY_STATE_TOPIC: TOPIC_SETTINGS,
     KEY_VALUE_TEMPLATE: TPL_VALVE_MIN_POSITION,
+    KEY_UNIT: UNIT_PERCENT,
+}
+OPTIONS_NUMBER_LIGHT_BRIGHTNESS = {
+    KEY_COMMAND_TOPIC: TOPIC_LIGHT_SET,
+    KEY_COMMAND_TEMPLATE: TPL_COMMAND_SET_BRIGHTNESS_WHITE_LIGHT,
+    KEY_ENABLED_BY_DEFAULT: True,
+    KEY_MIN: 0,
+    KEY_MAX: 100,
+    KEY_STEP: 1,
+    KEY_ICON: "mdi:brightness-percent",
+    KEY_STATE_TOPIC: TOPIC_LIGHT_STATUS,
+    KEY_VALUE_TEMPLATE: "{{value_json.brightness}}",
     KEY_UNIT: UNIT_PERCENT,
 }
 OPTIONS_BOOST_TIME = {
@@ -1639,6 +1653,7 @@ relay_binary_sensors = {}
 relay_sensors = {}
 light_binary_sensors = {}
 light_sensors = {}
+light_numbers = {}
 rgbw_lights = 0
 rollers = 0
 updates = {}
@@ -2195,6 +2210,9 @@ if model_id == MODEL_SHELLYDIMMER_ID or dev_id_prefix == MODEL_SHELLYDIMMER_PREF
         SENSOR_ENERGY: OPTIONS_SENSOR_LIGHT_ENERGY,
         SENSOR_OVERPOWER_VALUE: OPTIONS_SENSOR_LIGHT_OVERPOWER_VALUE,
     }
+    light_numbers = {
+        NUMBER_LIGHT_BRIGHTNESS: OPTIONS_NUMBER_LIGHT_BRIGHTNESS
+    }
     buttons = {BUTTON_RESTART: OPTIONS_BUTTON_RESTART}
     updates = {UPDATE_FIRMWARE: OPTIONS_UPDATE_FIRMWARE}
 
@@ -2229,6 +2247,9 @@ if model_id == MODEL_SHELLYDIMMER2_ID or dev_id_prefix == MODEL_SHELLYDIMMER2_PR
         SENSOR_POWER: OPTIONS_SENSOR_LIGHT_POWER,
         SENSOR_ENERGY: OPTIONS_SENSOR_LIGHT_ENERGY,
         SENSOR_OVERPOWER_VALUE: OPTIONS_SENSOR_LIGHT_OVERPOWER_VALUE,
+    }
+    light_numbers = {
+        NUMBER_LIGHT_BRIGHTNESS: OPTIONS_NUMBER_LIGHT_BRIGHTNESS
     }
     buttons = {BUTTON_RESTART: OPTIONS_BUTTON_RESTART}
     updates = {UPDATE_FIRMWARE: OPTIONS_UPDATE_FIRMWARE}
@@ -3392,6 +3413,42 @@ for light_id, light_options in white_lights.items():
             payload = ""
 
         mqtt_publish(config_topic, payload, retain)
+
+    # white light numbers
+    for number, number_options in light_numbers.items():
+        config_topic = f"{disc_prefix}/number/{dev_id}-white-{number}-{light_id}/config".encode(
+            "ascii", "ignore"
+        ).decode("utf-8")
+
+        payload = {
+            KEY_NAME: f"{device_name} {format_entity_name(number)} {light_id}",
+            KEY_COMMAND_TOPIC: number_options[KEY_COMMAND_TOPIC].format(light_id=light_id),
+            KEY_COMMAND_TEMPLATE: number_options[KEY_COMMAND_TEMPLATE].format(),
+            KEY_MAX: number_options[KEY_MAX],
+            KEY_MIN: number_options[KEY_MIN],
+            KEY_STEP: number_options[KEY_STEP],
+            KEY_STATE_TOPIC: number_options[KEY_STATE_TOPIC].format(light_id=light_id),
+            KEY_VALUE_TEMPLATE: number_options[KEY_VALUE_TEMPLATE],
+            KEY_UNIT: number_options[KEY_UNIT],
+            KEY_ENABLED_BY_DEFAULT: str(number_options[KEY_ENABLED_BY_DEFAULT]).lower(),
+            KEY_UNIQUE_ID: f"{dev_id}-white-{number}-{light_id}".lower(),
+            KEY_QOS: qos,
+            KEY_AVAILABILITY_TOPIC: TOPIC_ONLINE,
+            KEY_PAYLOAD_AVAILABLE: VALUE_TRUE,
+            KEY_PAYLOAD_NOT_AVAILABLE: VALUE_FALSE,
+            KEY_DEVICE: device_info,
+            "~": default_topic,
+        }
+        if number_options.get(KEY_ENTITY_CATEGORY):
+            payload[KEY_ENTITY_CATEGORY] = number_options[KEY_ENTITY_CATEGORY]
+        if number_options.get(KEY_DEVICE_CLASS):
+            payload[KEY_DEVICE_CLASS] = number_options[KEY_DEVICE_CLASS]
+        if number_options.get(ATTR_ICON):
+            payload[KEY_ICON] = number_options[ATTR_ICON]
+        if dev_id.lower() in ignored:
+            payload = ""
+
+        mqtt_publish(config_topic, payload, retain, json=True)
 
 # meter sensors
 for meter_id in range(meters):

--- a/python_scripts/shellies_discovery.py
+++ b/python_scripts/shellies_discovery.py
@@ -3431,7 +3431,7 @@ for light_id, light_options in white_lights.items():
             KEY_VALUE_TEMPLATE: number_options[KEY_VALUE_TEMPLATE],
             KEY_UNIT: number_options[KEY_UNIT],
             KEY_ENABLED_BY_DEFAULT: str(number_options[KEY_ENABLED_BY_DEFAULT]).lower(),
-            KEY_UNIQUE_ID: f"{dev_id}-white-{number}-{light_id}".lower(),
+            KEY_UNIQUE_ID: f"{dev_id}-{light_id}-{number}".lower(),
             KEY_QOS: qos,
             KEY_AVAILABILITY_TOPIC: TOPIC_ONLINE,
             KEY_PAYLOAD_AVAILABLE: VALUE_TRUE,

--- a/python_scripts/shellies_discovery.py
+++ b/python_scripts/shellies_discovery.py
@@ -3413,7 +3413,7 @@ for light_id, light_options in white_lights.items():
     # light numbers
     for number, number_options in light_numbers.items():
         config_topic = (
-            f"{disc_prefix}/number/{dev_id}-white-{number}-{light_id}/config".encode(
+            f"{disc_prefix}/number/{dev_id}-{light_id}-{number}/config".encode(
                 "ascii", "ignore"
             ).decode("utf-8")
         )

--- a/python_scripts/shellies_discovery.py
+++ b/python_scripts/shellies_discovery.py
@@ -3419,7 +3419,7 @@ for light_id, light_options in white_lights.items():
         )
 
         payload = {
-            KEY_NAME: f"{device_name} {format_entity_name(number)} {light_id}",
+            KEY_NAME: f"{device_name} Light {light_id} {number}",
             KEY_COMMAND_TOPIC: number_options[KEY_COMMAND_TOPIC].format(
                 light_id=light_id
             ),


### PR DESCRIPTION
This change adds a number input that can be used to set the brightness of the dimmer when the light is off.
Home Assistant by default only supports setting the dimmer brightness when turning the light on. This makes it not possible to set the brightness when using the physical switch attached to the dimmer before the light is turned on. For example when setting the brightness to low at night using an automation.